### PR TITLE
[build] Suppress Maven transfer progress logs in release validation script

### DIFF
--- a/scripts/validate_pulsar_release.sh
+++ b/scripts/validate_pulsar_release.sh
@@ -134,7 +134,7 @@ if [[ ! $LOCAL ]]; then
 
     if [[ ! -f apache-pulsar-$VERSION-src/build_ok && ! $SKIP_BUILD ]]; then
         cd apache-pulsar-$VERSION-src
-        mvn -B clean install -DskipTests
+        mvn -B -ntp clean install -DskipTests
         touch build_ok
         cd ..
     fi


### PR DESCRIPTION
The release validation script output is cluttered with Maven artifact download progress logs, which make up **approximately half of the total output**. This makes it difficult to read and track important build information.

This change adds the `-ntp` (no transfer progress) flag to the Maven command, which will suppress the artifact download progress logs while keeping other important build information visible. This makes the output cleaner and more focused on relevant build information.